### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+bs4
+prettytable
+requests
+pyreadline
+readline


### PR DESCRIPTION
readline does not work for windows 
so pyreadline is the alternative for windows.